### PR TITLE
feat(ui): add --host flag for binding address

### DIFF
--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -4,7 +4,7 @@
  * 
  * Usage:
  *   overseer-host mcp --cli-path /path/to/os --cwd /path/to/repo
- *   overseer-host ui --cli-path /path/to/os --cwd /path/to/repo --static-root /path/to/dist --port 6969
+ *   overseer-host ui --cli-path /path/to/os --cwd /path/to/repo --static-root /path/to/dist --host 127.0.0.1 --port 6969
  */
 import { configureCli } from "./cli.js";
 import { startMcpServer } from "./mcp.js";
@@ -16,6 +16,7 @@ interface Args {
   cwd: string;
   // UI-specific
   staticRoot?: string;
+  host?: string;
   port?: number;
 }
 
@@ -67,6 +68,14 @@ function parseArgs(argv: string[]): Args {
           process.exit(1);
         }
         result.staticRoot = next;
+        i++;
+        break;
+      case "--host":
+        if (!next) {
+          console.error("--host requires a value");
+          process.exit(1);
+        }
+        result.host = next;
         i++;
         break;
       case "--port":
@@ -124,11 +133,12 @@ Options:
 
 UI-specific options:
   --static-root <path>   Path to static files (required for UI mode)
+  --host <address>       Host to bind to (default: 127.0.0.1)
   --port <number>        HTTP port (default: 6969)
 
 Examples:
   overseer-host mcp --cli-path /usr/local/bin/os --cwd /home/user/project
-  overseer-host ui --cli-path ./os --cwd . --static-root ./dist --port 8080
+  overseer-host ui --cli-path ./os --cwd . --static-root ./dist --host 0.0.0.0 --port 8080
 `.trim());
 }
 
@@ -145,6 +155,7 @@ async function main(): Promise<void> {
     await startMcpServer();
   } else {
     await startUiServer({
+      host: args.host ?? "127.0.0.1",
       port: args.port ?? 6969,
       staticRoot: args.staticRoot ?? "./dist",
     });

--- a/host/src/ui.ts
+++ b/host/src/ui.ts
@@ -302,6 +302,7 @@ function createTaskRoutes() {
 }
 
 export interface UiServerConfig {
+  host: string;
   port: number;
   staticRoot: string;
 }
@@ -330,10 +331,11 @@ export async function startUiServer(config: UiServerConfig): Promise<void> {
   serve(
     {
       fetch: app.fetch,
+      hostname: config.host,
       port: config.port,
     },
     (info) => {
-      console.log(`Overseer UI: http://localhost:${info.port}`);
+      console.log(`Overseer UI: http://${config.host}:${info.port}`);
     }
   );
 }

--- a/overseer/src/main.rs
+++ b/overseer/src/main.rs
@@ -124,6 +124,9 @@ Requires Node.js and the @overseer/host package.
 "#
     )]
     Ui {
+        /// Host to bind to (default: 127.0.0.1)
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
         /// HTTP port (default: 6969)
         #[arg(long, short, default_value = "6969")]
         port: u16,
@@ -147,7 +150,7 @@ Requires Node.js and the @overseer/host package.
 /// Run the Node host server for UI or MCP mode.
 ///
 /// Resolves paths relative to the binary location and spawns Node.
-fn run_host_server(mode: &str, port: u16) {
+fn run_host_server(mode: &str, port: u16, host: &str) {
     // Get path to current executable
     let exe_path = std::env::current_exe().unwrap_or_else(|e| {
         eprintln!("Error: cannot determine executable path: {}", e);
@@ -196,6 +199,8 @@ fn run_host_server(mode: &str, port: u16) {
     if mode == "ui" {
         args.push("--static-root".to_string());
         args.push(static_root);
+        args.push("--host".to_string());
+        args.push(host.to_string());
         args.push("--port".to_string());
         args.push(port.to_string());
     }
@@ -314,12 +319,12 @@ fn main() {
     }
 
     // PRECONDITION: UI and MCP spawn Node processes, bypass normal run()
-    if let Command::Ui { port } = &cli.command {
-        run_host_server("ui", *port);
+    if let Command::Ui { host, port } = &cli.command {
+        run_host_server("ui", *port, host);
         return;
     }
     if let Command::Mcp = &cli.command {
-        run_host_server("mcp", 0);
+        run_host_server("mcp", 0, "127.0.0.1");
         return;
     }
 


### PR DESCRIPTION
I run my development on a server and accessing the UI via Tailscale seems sensible.