### PR TITLE
feat(mcp): support monorepo non-repo roots

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -714,10 +714,29 @@ os data export --json
 Launch the Task Viewer web UI:
 
 ```bash
-os ui [--port PORT]
+os ui [--port PORT] [--cwd PATH]
 ```
 
-Opens a web browser to the task visualization interface.
+**Arguments:**
+- `--port`: HTTP port (default: 6969)
+- `--cwd`: Working directory used by host for CLI task commands (default: current dir)
+
+**Monorepo note:** If workspace root is not a git/jj repo, set `--cwd` to a child repo path for workflow operations.
+
+### `os mcp`
+
+Launch the MCP server for agent codemode execution:
+
+```bash
+os mcp [--cwd PATH]
+```
+
+**Arguments:**
+- `--cwd`: Working directory used by host for CLI task commands (default: current dir)
+
+**Monorepo note:** If workspace root is not a git/jj repo, set `--cwd` to a child repo path, or pass `repoPath` to `tasks.start`/`tasks.complete`.
+
+Starts the MCP server over stdio for agent clients.
 
 ### `os init`
 
@@ -741,6 +760,12 @@ Supported shells: `bash`, `zsh`, `fish`, `powershell`, `elvish`
 
 ## Database Location
 
-SQLite database stored at: `$CWD/.overseer/tasks.db`
+SQLite database default path:
+
+1. `OVERSEER_DB_PATH` if set
+2. `<VCS_ROOT>/.overseer/tasks.db` if a git/jj root is found
+3. `<CWD>/.overseer/tasks.db` fallback
+
+When using `os ui`/`os mcp`, the resolved DB path is forwarded to host and pinned for all spawned CLI commands.
 
 **Note:** Run all `os` commands from your project root where `.overseer/` directory exists.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -139,10 +139,10 @@ tasks.update(id: string, input: {
 
 // State transitions
 // Start follows blockers to find startable work, cascades to deepest leaf
-tasks.start(id: string): Promise<Task>
+tasks.start(id: string, options?: { repoPath?: string }): Promise<Task>
 // Complete with optional result and learnings
 // Learnings bubble to immediate parent, auto-bubbles up completion if all siblings done
-tasks.complete(id: string, options?: { result?: string; learnings?: string[] }): Promise<Task>
+tasks.complete(id: string, options?: { result?: string; learnings?: string[]; repoPath?: string }): Promise<Task>
 tasks.reopen(id: string): Promise<Task>
 tasks.delete(id: string): Promise<void>
 
@@ -262,7 +262,9 @@ await tasks.complete(task.id, { result: "Login endpoint complete" });
 // -> Stores commit SHA on task
 ```
 
-**VCS is required** for `start` and `complete`. Fails with `NotARepository` if no jj/git found, `DirtyWorkingCopy` if uncommitted changes. CRUD operations (create, list, get, etc.) work without VCS.
+**VCS is required** for `start` and `complete`. Fails with `NotARepository` if no jj/git found, `DirtyWorkingCopy` if uncommitted changes. In monorepos where workspace root is not a repo, pass `repoPath` on workflow calls (absolute or relative to host cwd). CRUD operations (create, list, get, etc.) work without VCS.
+
+When provided, `repoPath` must exist and be a directory.
 
 ### Error Handling
 

--- a/host/src/api/tasks.ts
+++ b/host/src/api/tasks.ts
@@ -65,6 +65,10 @@ export interface UpdateTaskInput {
   parentId?: string;
 }
 
+export interface WorkflowRepoOptions {
+  repoPath?: string;
+}
+
 /**
  * Tasks API exposed to VM sandbox
  */
@@ -155,8 +159,10 @@ export const tasks = {
    *
    * **Requires VCS**: Must be in a jj or git repository.
    */
-  async start(id: string): Promise<Task> {
-    return decodeTask(await callCli(["task", "start", id])).unwrap("tasks.start");
+  async start(id: string, options?: WorkflowRepoOptions): Promise<Task> {
+    return decodeTask(await callCli(["task", "start", id], { cwd: options?.repoPath })).unwrap(
+      "tasks.start"
+    );
   },
 
   /**
@@ -169,7 +175,7 @@ export const tasks = {
    */
   async complete(
     id: string,
-    options?: { result?: string; learnings?: string[] }
+    options?: { result?: string; learnings?: string[]; repoPath?: string }
   ): Promise<Task> {
     const args = ["task", "complete", id];
     if (options?.result) args.push("--result", options.result);
@@ -178,7 +184,7 @@ export const tasks = {
         args.push("--learning", learning);
       }
     }
-    return decodeTask(await callCli(args)).unwrap("tasks.complete");
+    return decodeTask(await callCli(args, { cwd: options?.repoPath })).unwrap("tasks.complete");
   },
 
   /**

--- a/host/src/cli.ts
+++ b/host/src/cli.ts
@@ -5,28 +5,109 @@
  * This allows the Rust CLI to set paths correctly when spawning.
  */
 import { spawn } from "node:child_process";
-import { CliError, CliTimeoutError } from "./types.js";
+import { statSync } from "node:fs";
+import path from "node:path";
+import { CliError, CliTimeoutError, InvalidPathError } from "./types.js";
 
 const CLI_TIMEOUT_MS = 30_000;
 
 export interface CliConfig {
   /** Path to the os binary */
   cliPath: string;
-  /** Working directory for CLI commands */
+  /** Base working directory for CLI commands */
   cwd: string;
+  /** Pinned DB path for all CLI commands */
+  dbPath: string;
+}
+
+export interface CallCliOptions {
+  /** Optional per-call cwd override (absolute or relative to base cwd) */
+  cwd?: string;
 }
 
 // Global config, set by main entry point
 let config: CliConfig = {
   cliPath: "os",
-  cwd: process.cwd(),
+  cwd: path.resolve(process.cwd()),
+  dbPath: ".overseer/tasks.db",
 };
+
+/**
+ * Resolve a cwd override against base cwd and validate it.
+ */
+export function resolveCliCwd(cwdOverride?: string): string {
+  if (cwdOverride === undefined) {
+    return config.cwd;
+  }
+
+  const resolved = path.resolve(config.cwd, cwdOverride);
+
+  let stats;
+  try {
+    stats = statSync(resolved);
+  } catch {
+    throw new InvalidPathError(`Path does not exist: ${cwdOverride}`, cwdOverride);
+  }
+
+  if (!stats.isDirectory()) {
+    throw new InvalidPathError(`Path is not a directory: ${cwdOverride}`, cwdOverride);
+  }
+
+  return resolved;
+}
+
+function parseCliErrorMessage(stderr: string, code: number | null): string {
+  const trimmed = stderr.trim();
+  if (trimmed.length === 0) {
+    return `os exited with code ${code ?? "unknown"}`;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed !== null && typeof parsed === "object") {
+      const maybeError = Reflect.get(parsed, "error");
+      if (typeof maybeError === "string") {
+        return maybeError;
+      }
+    }
+  } catch {
+    // Keep original stderr text if not JSON.
+  }
+
+  return trimmed;
+}
+
+function isWorkflowCommand(args: string[]): boolean {
+  return args.length >= 2 && args[0] === "task" && (args[1] === "start" || args[1] === "complete");
+}
+
+function addWorkflowRepoHint(message: string, args: string[]): string {
+  if (!isWorkflowCommand(args)) {
+    return message;
+  }
+
+  const lower = message.toLowerCase();
+  const isNotRepo = lower.includes("not in a repository") || lower.includes("not a repository");
+  if (!isNotRepo || lower.includes("repopath") || lower.includes("--cwd")) {
+    return message;
+  }
+
+  return `${message} For monorepo roots without VCS, pass repoPath to workflow calls (tasks.start/tasks.complete) or launch with --cwd <repo-path>.`;
+}
 
 /**
  * Configure the CLI bridge
  */
 export function configureCli(newConfig: CliConfig): void {
-  config = newConfig;
+  const baseCwd = path.resolve(newConfig.cwd);
+  const dbPath = path.isAbsolute(newConfig.dbPath)
+    ? newConfig.dbPath
+    : path.resolve(baseCwd, newConfig.dbPath);
+  config = {
+    cliPath: newConfig.cliPath,
+    cwd: baseCwd,
+    dbPath,
+  };
 }
 
 /**
@@ -39,10 +120,12 @@ export function getCliConfig(): CliConfig {
 /**
  * Execute os CLI command with --json flag
  */
-export async function callCli(args: string[]): Promise<unknown> {
+export async function callCli(args: string[], options?: CallCliOptions): Promise<unknown> {
+  const resolvedCwd = resolveCliCwd(options?.cwd);
+
   return new Promise((resolve, reject) => {
-    const proc = spawn(config.cliPath, [...args, "--json"], {
-      cwd: config.cwd,
+    const proc = spawn(config.cliPath, [...args, "--db", config.dbPath, "--json"], {
+      cwd: resolvedCwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -71,7 +154,7 @@ export async function callCli(args: string[]): Promise<unknown> {
       clearTimeout(timeout);
 
       if (code !== 0) {
-        const message = stderr.trim() || `os exited with code ${code}`;
+        const message = addWorkflowRepoHint(parseCliErrorMessage(stderr, code), args);
         reject(new CliError(message, code ?? -1, stderr));
         return;
       }

--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -3,8 +3,8 @@
  * Overseer Host - Unified entry point for MCP and UI servers
  * 
  * Usage:
- *   overseer-host mcp --cli-path /path/to/os --cwd /path/to/repo
- *   overseer-host ui --cli-path /path/to/os --cwd /path/to/repo --static-root /path/to/dist --port 6969
+ *   overseer-host mcp --cli-path /path/to/os --cwd /path/to/repo --db-path /path/to/tasks.db
+ *   overseer-host ui --cli-path /path/to/os --cwd /path/to/repo --db-path /path/to/tasks.db --static-root /path/to/dist --port 6969
  */
 import { configureCli } from "./cli.js";
 import { startMcpServer } from "./mcp.js";
@@ -14,6 +14,7 @@ interface Args {
   mode: "mcp" | "ui";
   cliPath: string;
   cwd: string;
+  dbPath: string;
   // UI-specific
   staticRoot?: string;
   port?: number;
@@ -38,6 +39,7 @@ function parseArgs(argv: string[]): Args {
     mode,
     cliPath: "os",
     cwd: process.cwd(),
+    dbPath: ".overseer/tasks.db",
   };
 
   for (let i = 1; i < args.length; i++) {
@@ -59,6 +61,14 @@ function parseArgs(argv: string[]): Args {
           process.exit(1);
         }
         result.cwd = next;
+        i++;
+        break;
+      case "--db-path":
+        if (!next) {
+          console.error("--db-path requires a value");
+          process.exit(1);
+        }
+        result.dbPath = next;
         i++;
         break;
       case "--static-root":
@@ -121,14 +131,15 @@ Modes:
 Options:
   --cli-path <path>      Path to os binary (default: "os" in PATH)
   --cwd <path>           Working directory for CLI commands (default: current dir)
+  --db-path <path>       Database path passed to os --db (default: .overseer/tasks.db)
 
 UI-specific options:
   --static-root <path>   Path to static files (required for UI mode)
   --port <number>        HTTP port (default: 6969)
 
 Examples:
-  overseer-host mcp --cli-path /usr/local/bin/os --cwd /home/user/project
-  overseer-host ui --cli-path ./os --cwd . --static-root ./dist --port 8080
+  overseer-host mcp --cli-path /usr/local/bin/os --cwd /home/user/project --db-path /home/user/project/.overseer/tasks.db
+  overseer-host ui --cli-path ./os --cwd . --db-path ./.overseer/tasks.db --static-root ./dist --port 8080
 `.trim());
 }
 
@@ -139,6 +150,7 @@ async function main(): Promise<void> {
   configureCli({
     cliPath: args.cliPath,
     cwd: args.cwd,
+    dbPath: args.dbPath,
   });
 
   if (args.mode === "mcp") {

--- a/host/src/mcp.ts
+++ b/host/src/mcp.ts
@@ -85,8 +85,8 @@ declare const tasks: {
     priority?: 0 | 1 | 2;
     parentId?: string;
   }): Promise<Task>;
-  start(id: string): Promise<Task>;  // VCS required: creates bookmark, records start commit
-  complete(id: string, options?: { result?: string; learnings?: string[] }): Promise<Task>;  // VCS required: commits changes (NothingToCommit = success)
+  start(id: string, options?: { repoPath?: string }): Promise<Task>;  // VCS required: creates bookmark, records start commit
+  complete(id: string, options?: { result?: string; learnings?: string[]; repoPath?: string }): Promise<Task>;  // VCS required: commits changes (NothingToCommit = success)
   reopen(id: string): Promise<Task>;
   cancel(id: string): Promise<Task>;  // Cancel task (does NOT satisfy blockers)
   archive(id: string): Promise<Task>;  // Archive completed/cancelled task (hides from default list)
@@ -105,7 +105,7 @@ declare const learnings: {
 };
 \`\`\`
 
-**VCS Requirement:** \`start\` and \`complete\` require jj or git. Fails with NotARepository error if none found. CRUD operations work without VCS.
+**VCS Requirement:** \`start\` and \`complete\` require jj or git. Fails with NotARepository error if none found. In monorepos where root is not a repo, pass \`repoPath\` (absolute or relative to host cwd) for workflow calls. \`repoPath\` must exist and be a directory. CRUD operations work without VCS.
 
 Examples:
 

--- a/host/src/types.ts
+++ b/host/src/types.ts
@@ -150,3 +150,13 @@ export class CliTimeoutError extends Error {
     this.name = "CliTimeoutError";
   }
 }
+
+export class InvalidPathError extends Error {
+  constructor(
+    message: string,
+    public pathValue: string
+  ) {
+    super(message);
+    this.name = "InvalidPathError";
+  }
+}

--- a/overseer/src/main.rs
+++ b/overseer/src/main.rs
@@ -127,6 +127,10 @@ Requires Node.js and the @overseer/host package.
         /// HTTP port (default: 6969)
         #[arg(long, short, default_value = "6969")]
         port: u16,
+
+        /// Working directory for host CLI commands (default: current dir)
+        #[arg(long)]
+        cwd: Option<PathBuf>,
     },
 
     /// Start the MCP server (for AI agents)
@@ -141,13 +145,17 @@ for AI agents to manage tasks programmatically.
 Requires Node.js and the @overseer/host package.
 "#
     )]
-    Mcp,
+    Mcp {
+        /// Working directory for host CLI commands (default: current dir)
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+    },
 }
 
 /// Run the Node host server for UI or MCP mode.
 ///
 /// Resolves paths relative to the binary location and spawns Node.
-fn run_host_server(mode: &str, port: u16) {
+fn run_host_server(mode: &str, port: u16, cwd_override: Option<PathBuf>, db_path: PathBuf) {
     // Get path to current executable
     let exe_path = std::env::current_exe().unwrap_or_else(|e| {
         eprintln!("Error: cannot determine executable path: {}", e);
@@ -158,10 +166,13 @@ fn run_host_server(mode: &str, port: u16) {
     let cli_path = exe_path.to_string_lossy().to_string();
 
     // Working directory for CLI commands
-    let cwd = std::env::current_dir().unwrap_or_else(|e| {
-        eprintln!("Error: cannot determine current directory: {}", e);
-        std::process::exit(1);
-    });
+    let cwd = match cwd_override {
+        Some(path) => path,
+        None => std::env::current_dir().unwrap_or_else(|e| {
+            eprintln!("Error: cannot determine current directory: {}", e);
+            std::process::exit(1);
+        }),
+    };
 
     // Find the host package relative to the binary
     // In dev: binary is at target/release/os, host is at ../../../host/dist/index.js
@@ -191,6 +202,8 @@ fn run_host_server(mode: &str, port: u16) {
         cli_path,
         "--cwd".to_string(),
         cwd.to_string_lossy().to_string(),
+        "--db-path".to_string(),
+        db_path.to_string_lossy().to_string(),
     ];
 
     if mode == "ui" {
@@ -304,6 +317,16 @@ fn default_db_path() -> PathBuf {
     base.join(".overseer").join("tasks.db")
 }
 
+fn default_db_path_from(base_dir: &PathBuf) -> PathBuf {
+    if let Ok(path) = std::env::var("OVERSEER_DB_PATH") {
+        return PathBuf::from(path);
+    }
+
+    let (_, vcs_root) = vcs::detect_vcs_type(base_dir);
+    let base = vcs_root.unwrap_or_else(|| base_dir.clone());
+    base.join(".overseer").join("tasks.db")
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -314,12 +337,38 @@ fn main() {
     }
 
     // PRECONDITION: UI and MCP spawn Node processes, bypass normal run()
-    if let Command::Ui { port } = &cli.command {
-        run_host_server("ui", *port);
+    if let Command::Ui { port, cwd } = &cli.command {
+        let base_dir = cwd
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        let db_path = match &cli.db {
+            Some(db) => {
+                if db.is_absolute() {
+                    db.clone()
+                } else {
+                    base_dir.join(db)
+                }
+            }
+            None => default_db_path_from(&base_dir),
+        };
+        run_host_server("ui", *port, cwd.clone(), db_path);
         return;
     }
-    if let Command::Mcp = &cli.command {
-        run_host_server("mcp", 0);
+    if let Command::Mcp { cwd } = &cli.command {
+        let base_dir = cwd
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        let db_path = match &cli.db {
+            Some(db) => {
+                if db.is_absolute() {
+                    db.clone()
+                } else {
+                    base_dir.join(db)
+                }
+            }
+            None => default_db_path_from(&base_dir),
+        };
+        run_host_server("mcp", 0, cwd.clone(), db_path);
         return;
     }
 
@@ -431,7 +480,7 @@ fn run(command: &Command, db_path: &PathBuf) -> error::Result<String> {
         Command::Completions { .. } => unreachable!("completions handled before run()"),
         // PRECONDITION: UI and MCP handled in main() before run() is called
         Command::Ui { .. } => unreachable!("ui handled before run()"),
-        Command::Mcp => unreachable!("mcp handled before run()"),
+        Command::Mcp { .. } => unreachable!("mcp handled before run()"),
     }
 }
 

--- a/overseer/src/output.rs
+++ b/overseer/src/output.rs
@@ -246,7 +246,7 @@ impl Printer {
             Command::Completions { .. } => unreachable!("completions handled before print()"),
             // PRECONDITION: UI and MCP handled in main() before print() is called
             Command::Ui { .. } => unreachable!("ui handled before print()"),
-            Command::Mcp => unreachable!("mcp handled before print()"),
+            Command::Mcp { .. } => unreachable!("mcp handled before print()"),
         }
     }
 


### PR DESCRIPTION
## Summary
- add `--cwd` support to `os mcp` and `os ui` and forward pinned `--db-path` to host
- extend workflow APIs with optional `repoPath` so `tasks.start/complete` can target child repos in monorepos
- align DB path resolution with effective cwd to avoid task DB split when root is not a repo
- update CLI and MCP docs for monorepo workflow usage and `repoPath` constraints

## Validation
- `cd host && npm run build:check`
- `cd overseer && cargo test`